### PR TITLE
feat: support 0x address format for FIL-EVM and add panic recovery in…

### DIFF
--- a/cmd/verifyaddress/main.go
+++ b/cmd/verifyaddress/main.go
@@ -69,12 +69,20 @@ func parseLine(line string) []string {
 	return result
 }
 
-func handle(i int, line string) (string, bool) {
+func handle(i int, line string) (coin string, success bool) {
 	if len(line) == 0 {
 		return "", true
 	}
 	as := parseLine(line)
 	coin, addr, balance, message, sign1, sign2, script := as[0], as[3], as[4], as[5], as[6], as[7], as[8]
+
+	// Recover from panic and print detailed error info
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Printf("PANIC at line %d: %v | coin=%s, addr=%s, balance=%s, message=%s, sign1=%s, sign2=%s, script=%s\n", i+1, r, coin, addr, balance, message, sign1, sign2, script)
+			success = false
+		}
+	}()
 	var eoa1, eoa2 string
 	if len(as) > 10 {
 		eoa1 = as[9]

--- a/common/verify.go
+++ b/common/verify.go
@@ -270,12 +270,17 @@ func VerifyEvmCoin(coin, addr, msg, sign string) error {
 	}
 	switch addrType {
 	case "FIL":
-		// convert eth address to fil address
-		filAddress, err := ConvertEthAddressToFilecoinAddress(PubkeyToAddress(*pubToEcdsa).Bytes())
-		if err != nil {
-			return fmt.Errorf("convert eth address to fil address failed, coin:%s, addr:%s, error:%v", coin, addr, err)
+		if strings.HasPrefix(strings.ToLower(addr), "0x") {
+			// 0x address, compare directly with ETH address
+			recoverAddr = PubkeyToAddress(*pubToEcdsa).String()
+		} else {
+			// f410 address, convert to filecoin address
+			filAddress, err := ConvertEthAddressToFilecoinAddress(PubkeyToAddress(*pubToEcdsa).Bytes())
+			if err != nil {
+				return fmt.Errorf("convert eth address to fil address failed, coin:%s, addr:%s, error:%v", coin, addr, err)
+			}
+			recoverAddr = filAddress.String()
 		}
-		recoverAddr = filAddress.String()
 	case "LAT":
 		ethAddress := PubkeyToAddress(*pubToEcdsa).String()
 		recoverAddr, _ = ConvertETHToLATAddress(ethAddress)


### PR DESCRIPTION
… verify

- FIL-EVM now supports both 0x and f410 address formats
- Add defer/recover in handle() to catch panics with detailed error info